### PR TITLE
Add support for mu-cl-resources based searching

### DIFF
--- a/app/components/search-table/mu-search/header.hbs
+++ b/app/components/search-table/mu-search/header.hbs
@@ -1,0 +1,31 @@
+<AuDataTableThSortable
+  @label="Provincie"
+  @field="province"
+  @currentSorting={{@sort}}
+  @class="data-table__header-title au-u-visible-from@medium"
+/>
+<AuDataTableThSortable
+  @label="Bestuurseenheid"
+  @field="administrativeUnit"
+  @currentSorting={{@sort}}
+  @class="data-table__header-title"
+/>
+<AuDataTableThSortable
+  @label="Type bestuur"
+  @field="administrativeUnitClassification"
+  @currentSorting={{@sort}}
+  @class="data-table__header-title au-u-visible-from@medium"
+/>
+<AuDataTableThSortable
+  @label="Categorie dossier"
+  @field="decisionType"
+  @currentSorting={{@sort}}
+  @class="data-table__header-title"
+/>
+<AuDataTableThSortable
+  @label="Periode zitting / besluit"
+  @field="sessionDatetime"
+  @currentSorting={{@sort}}
+  @class="data-table__header-title au-u-visible-from@medium"
+/>
+<th class="au-u-hide-on-print"></th>

--- a/app/components/search-table/mu-search/row.hbs
+++ b/app/components/search-table/mu-search/row.hbs
@@ -1,0 +1,30 @@
+<td class="au-u-visible-from@medium">{{@submission.province}}</td>
+<td style="max-width: 175px;" {{! template-lint-disable no-inline-styles }}>
+  {{@submission.administrativeUnit}}
+  <p class="text-fade">{{@submission.administrativeUnitClassification}}</p>
+</td>
+<td class="au-u-visible-from@medium">
+  {{@submission.administrativeUnitClassification}}
+</td>
+<td style="max-width: 200px;" {{! template-lint-disable no-inline-styles }}>
+  {{#if @submission.decisionType}}
+    <p>{{@submission.decisionType}}</p>
+  {{else}}
+    <AuHelpText>Geen type</AuHelpText>
+  {{/if}}
+  <AuHelpText>{{@submission.regulationType}}</AuHelpText>
+</td>
+<td class="au-u-visible-from@medium">{{moment-format
+    @submission.sessionDatetime
+    "DD-MM-YYYY HH:mm"
+  }}</td>
+<td
+  class="au-u-hide-on-print"
+  style="width:70px;"
+  {{! template-lint-disable no-inline-styles }}
+>
+  <AuLink
+    @route="search.submissions.show"
+    @model={{@submission.id}}
+  >Bekijk</AuLink>
+</td>

--- a/app/components/search-table/resource/header.hbs
+++ b/app/components/search-table/resource/header.hbs
@@ -1,0 +1,31 @@
+<AuDataTableThSortable
+  @label="Provincie"
+  @field="organization.provincie.naam"
+  @currentSorting={{@sort}}
+  @class="data-table__header-title au-u-visible-from@medium"
+/>
+<AuDataTableThSortable
+  @label="Bestuurseenheid"
+  @field="organization.naam"
+  @currentSorting={{@sort}}
+  @class="data-table__header-title"
+/>
+<AuDataTableThSortable
+  @label="Type bestuur"
+  @field="organization.classificatie.label"
+  @currentSorting={{@sort}}
+  @class="data-table__header-title au-u-visible-from@medium"
+/>
+<AuDataTableThSortable
+  @label="Categorie dossier"
+  @field="formData.decisionType"
+  @currentSorting={{@sort}}
+  @class="data-table__header-title"
+/>
+<AuDataTableThSortable
+  @label="Periode zitting / besluit"
+  @field="formData.sessionStartedAtTime"
+  @currentSorting={{@sort}}
+  @class="data-table__header-title au-u-visible-from@medium"
+/>
+<th class="au-u-hide-on-print"></th>

--- a/app/components/search-table/resource/row.hbs
+++ b/app/components/search-table/resource/row.hbs
@@ -1,0 +1,35 @@
+<td class="au-u-visible-from@medium">{{@submission.organization.provincie.naam}}</td>
+<td style="max-width: 175px;" {{! template-lint-disable no-inline-styles }}>
+  {{@submission.organization.naam}}
+  {{!-- <p class="au-u-visible-from text-fade">{{@submission.organization.classificatie.label}}</p> --}}
+  <AuHelpText class="au-u-hidden-from@medium">{{@submission.organization.classificatie.label}}</AuHelpText>
+</td>
+<td class="au-u-visible-from@medium">
+  {{@submission.organization.classificatie.label}}
+</td>
+<td style="max-width: 200px;" {{! template-lint-disable no-inline-styles }}>
+  {{#if @submission.formData.decisionType}}
+    <p>{{@submission.formData.decisionType.label}}</p>
+  {{else}}
+    <AuHelpText>Geen type</AuHelpText>
+  {{/if}}
+  <AuHelpText>{{@submission.formData.regulationType.label}}</AuHelpText>
+</td>
+<td class="au-u-visible-from@medium">
+  {{#if @submission.formData.sessionStartedAtTime}}
+    {{moment-format
+      @submission.formData.sessionStartedAtTime
+      "DD-MM-YYYY HH:mm"
+    }}
+  {{/if}}
+</td>
+<td
+  class="au-u-hide-on-print"
+  style="width:70px;"
+  {{! template-lint-disable no-inline-styles }}
+>
+  <AuLink
+    @route="search.submissions.show"
+    @model={{@submission.id}}
+  >Bekijk</AuLink>
+</td>

--- a/app/components/submissions/search-table.hbs
+++ b/app/components/submissions/search-table.hbs
@@ -17,36 +17,18 @@
             @size={{@size}} as |t|>
           <t.content class="au-c-data-table__table--small" as |c|>
             <c.header>
-              <AuDataTableThSortable @label="Provincie" @field="province" @currentSorting={{@sort}} @class="data-table__header-title au-u-visible-from@medium"/>
-              <AuDataTableThSortable @label="Bestuurseenheid" @field="administrativeUnit" @currentSorting={{@sort}} @class="data-table__header-title"/>
-              <AuDataTableThSortable @label="Type bestuur" @field="administrativeUnitClassification" @currentSorting={{@sort}} @class="data-table__header-title au-u-visible-from@medium"/>
-              <AuDataTableThSortable @label="Categorie dossier" @field="decisionType" @currentSorting={{@sort}} @class="data-table__header-title"/>
-              <AuDataTableThSortable @label="Periode zitting / besluit" @field="sessionDatetime" @currentSorting={{@sort}} @class="data-table__header-title au-u-visible-from@medium"/>
-              <th class="au-u-hide-on-print"></th>
+              {{#if @usesMuSearch}}
+                <SearchTable::MuSearch::Header @sort={{@sort}} />
+              {{else}}
+                <SearchTable::Resource::Header @sort={{@sort}} />
+              {{/if}}
             </c.header>
-            <c.body as |row|>
-
-              <td class="au-u-visible-from@medium">{{row.province}}</td>
-
-              <td style="max-width: 175px;" {{! template-lint-disable no-inline-styles }}>
-                {{row.administrativeUnit}}
-                <p class="text-fade">{{row.administrativeUnitClassification}}</p>
-              </td>
-
-              <td class="au-u-visible-from@medium">{{row.administrativeUnitClassification}}</td>
-
-              <td style="max-width: 200px;" {{! template-lint-disable no-inline-styles }}>
-                {{#if row.decisionType}}
-                  <p>{{row.decisionType}}</p>
-                {{else}}
-                  <AuHelpText>Geen type</AuHelpText>
-                {{/if}}
-                <AuHelpText>{{row.regulationType}}</AuHelpText>
-              </td>
-              <td class="au-u-visible-from@medium">{{moment-format row.sessionDatetime 'DD-MM-YYYY HH:mm'}}</td>
-              <td class="au-u-hide-on-print" style="width:70px;" {{! template-lint-disable no-inline-styles }}>
-                <AuLink @route="search.submissions.show" @model={{row.id}}>Bekijk</AuLink>
-              </td>
+            <c.body as |submission|>
+              {{#if @usesMuSearch}}
+                <SearchTable::MuSearch::Row @submission={{submission}} />
+              {{else}}
+                <SearchTable::Resource::Row @submission={{submission}} />
+              {{/if}}
             </c.body>
             <tr>
             <td colspan="8">

--- a/app/templates/search/submissions.hbs
+++ b/app/templates/search/submissions.hbs
@@ -9,13 +9,16 @@
                 <AuHeading @level="1" @skin="2" class="au-u-margin-top-tiny au-u-margin-bottom-tiny">{{app-name}}</AuHeading>
               </Group>
             </AuToolbar>
-            <Submissions::SearchTable @model={{this.model}}
-                                      @isLoading={{this.isLoadingModel}}
-                                      @queryParams={{this.filter}}
-                                      @sort={{this.sort}}
-                                      @page={{this.page}}
-                                      @size={{this.size}}
-                                      @displaySubset={{this.hasActiveChildRoute}}/>
+            <Submissions::SearchTable
+              @model={{this.model}}
+              @isLoading={{this.isLoadingModel}}
+              @queryParams={{this.filter}}
+              @sort={{this.sort}}
+              @page={{this.page}}
+              @size={{this.size}}
+              @displaySubset={{this.hasActiveChildRoute}}
+              @usesMuSearch={{this.usesMuSearch}}
+            />
           </div>
         </div>
         {{outlet}}


### PR DESCRIPTION
The current mu-search implementation has issues with generating a lot of indexes so we add support for mu-cl-resources as a workaround.

Draft PR since I only tested this with the Public decisions DB as a proxy.