### PR TITLE
Adding "Datum verstuurd" column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.6.0 (2023-03-24)
+
+- Adding "Datum verstuurd" columns and rows in the header component to display the sent date from a submission.
+- Bumping @appuniversum/ember-appuniversum to v2.3.0 and ember-cli-htmlbars to v6.2.0

--- a/app/components/search-table/mu-search/header.hbs
+++ b/app/components/search-table/mu-search/header.hbs
@@ -28,4 +28,10 @@
   @currentSorting={{@sort}}
   @class="data-table__header-title au-u-visible-from@medium"
 />
+<AuDataTableThSortable
+  @label="Datum verstuurd"
+  @field="sentDate"
+  @currentSorting={{@sort}}
+  @class="data-table__header-title au-u-visible-from@medium"
+/>
 <th class="au-u-hide-on-print"></th>

--- a/app/components/search-table/mu-search/row.hbs
+++ b/app/components/search-table/mu-search/row.hbs
@@ -18,6 +18,11 @@
     @submission.sessionDatetime
     "DD-MM-YYYY HH:mm"
   }}</td>
+<td class="au-u-visible-from@medium">{{moment-format
+    @submission.sentDate
+    "DD-MM-YYYY HH:mm"
+  }}
+</td>
 <td
   class="au-u-hide-on-print"
   style="width:70px;"

--- a/app/components/search-table/resource/header.hbs
+++ b/app/components/search-table/resource/header.hbs
@@ -28,4 +28,10 @@
   @currentSorting={{@sort}}
   @class="data-table__header-title au-u-visible-from@medium"
 />
+<AuDataTableThSortable
+  @label="Datum verstuurd"
+  @field="sentDate"
+  @currentSorting={{@sort}}
+  @class="data-table__header-title au-u-visible-from@medium"
+/>
 <th class="au-u-hide-on-print"></th>

--- a/app/components/search-table/resource/row.hbs
+++ b/app/components/search-table/resource/row.hbs
@@ -23,6 +23,14 @@
     }}
   {{/if}}
 </td>
+<td class="au-u-visible-from@medium">
+  {{#if @submission.sentDate}}
+    {{moment-format
+    @submission.sentDate
+    "DD-MM-YYYY HH:mm"
+  }}
+  {{/if}}
+</td>
 <td
   class="au-u-hide-on-print"
   style="width:70px;"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "ember-style-modifier": "^0.8.0"
   },
   "devDependencies": {
-    "@appuniversum/ember-appuniversum": "^1.3.0",
+    "@appuniversum/ember-appuniversum": "^2.3.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/render-modifiers": "^2.0.4",
     "@ember/test-helpers": "^2.6.0",
@@ -53,7 +53,7 @@
     "ember-cli-deploy-revision-data": "^2.0.0",
     "ember-cli-deploy-rsync": "0.0.5",
     "ember-cli-deploy-ssh-index": "^1.0.0",
-    "ember-cli-htmlbars": "^5.7.2",
+    "ember-cli-htmlbars": "^6.2.0",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sass": "^11.0.1",
     "ember-cli-sri": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-worship-decisions",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "description": "Frontend of the Worship Decisions application",
   "repository": {


### PR DESCRIPTION
DL-4903

Adding a new column "Datum verstuurd" to show the submission sent date from loket.

When submissions gets ingested, we now send the "sentDate" of a submission and a worship-submission so we can display it in the table.

To be merged with : https://github.com/lblod/app-digitaal-loket/pull/367

### How to test :

You will need to run both `app-digitaal-loket` on branch `hotfix/add-submission-sentDate-predicate` and `app-worship-decisions-database` on any branch.

What you will need as `app-worship-decision-database` setting in your docker-compose file :

``` yml
  ################################################################################
  # DELTAS
  ################################################################################
  submissions-consumer:
    image: lblod/delta-consumer:0.0.15
    environment:
      DCR_SYNC_BASE_URL: "http://0.0.0.0:90" # 0.0.0.0 is just for the sake of the example. To know your address use hostname -I in your linux terminal, it should be the first one to pickup. 
      DCR_SYNC_LOGIN_ENDPOINT: 'http://0.0.0.0:90/sync/worship-submissions/login' # don't forget DCR_SECRET_KEY in docker-compose.override.yml
      DCR_SERVICE_NAME: "submissions-consumer"
      DCR_SYNC_FILES_PATH: "/sync/worship-submissions/files"
      DCR_SYNC_DATASET_SUBJECT: "http://data.lblod.info/datasets/delta-producer/dumps/WorshipSubmissionsCacheGraphDump"
      DCR_INITIAL_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/initialSync/submissions"
      DCR_JOB_CREATOR_URI: "http://data.lblod.info/services/id/submissions-consumer"
      DCR_DISABLE_INITIAL_SYNC: "true"
      DCR_KEEP_DELTA_FILES: "true"
      DCR_SECRET_KEY: "your_secret_key" # This is important as you need it to sync the app same as the app-digitaal-loket env KEY.
      DCR_START_FROM_DELTA_TIMESTAMP: "2023-03-12T16:26:00.596Z"
      DCR_WAIT_FOR_INITIAL_SYNC: 'false'
      DCR_DELTA_FILE_FOLDER: "/consumer-files"
      DCR_DELTA_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/sumbissionFileSyncing"
      INGEST_GRAPH: "http://mu.semte.ch/graphs/temp/for-dispatch"
      FILE_SYNC_GRAPH: "http://mu.semte.ch/graphs/temp/original-physical-files-data"
    volumes:
      - ./config/submissions-consumer/submissions-dispatching:/config/triples-dispatching/custom-dispatching
      - ./data/files/consumer-files/submissions:/consumer-files/
      - ./data/files:/share
    restart: always
    logging: *default-logging
  files-consumer:
    image: lblod/delta-consumer-file-sync-submissions:0.5.1
    environment:
      DISABLE_AUTOMATIC_SYNC: "true"
      DISABLE_INITIAL_SYNC: "true"
      FILES_ENDPOINT_BASE_URL: "http://0.0.0.0:90"
      SYNC_LOGIN_ENDPOINT: "http://0.0.0.0:90/sync/worship-submissions/login" # don't forget SECRET_KEY in docker-compose.override.yml
      SOURCE_FILES_DATA_GRAPH: "http://mu.semte.ch/graphs/temp/original-physical-files-data"
    volumes:
      - ./data/files:/share
```
And for the frontend replace the image by this one : 

``` yml
frontend:
    image: poltergeistz/frontend-worship-decisions-local:latest #lblod/frontend-worship-decisions:0.5.0
```

In app-digitaal-loket add this after making sure you are on branch `hotfix/add-submission-sentDate-predicate` :

``` yml
  delta-producer-publication-graph-maintainer-worship-submissions:
    environment:
      ...
      WAIT_FOR_INITIAL_SYNC: "false"
      KEY: "your_secret_key" # This is important as you need it to sync the app.
```
- docker-compose up -d both projects
- Send a submission from loket with a worship administrative unit. E.g CKB Aalst
- Check in `app-worship-decisions-database` if the datum vestuurd field has your submission sent date.

At this state it's working but might be worth double checking.