### PR TITLE
[Melding functionaliteit] Adding core features

### DIFF
--- a/app/components/submissions/notification-preferences.hbs
+++ b/app/components/submissions/notification-preferences.hbs
@@ -1,0 +1,53 @@
+<AuModal
+  @id="notification-preferences"
+  @title="Configureer meldingen"
+  @modalOpen={{true}}
+  @closeModal={{@close}}
+  ...attributes
+  as |Modal|
+>
+  <Modal.Body>
+    <AuHeading @level="2" @skin="4" class="au-u-margin-bottom-small">
+      Mail instellingen
+    </AuHeading>
+    <form
+      id="notification-preferences-form"
+      class="au-o-flow--small"
+      {{on "submit" this.savePreferences}}
+    >
+      <AuControlCheckbox
+        @label="Ontvang mails bij nieuwe inzendingen"
+        @checked={{this.wilMailOntvangen}}
+        @onChange={{fn (mut this.wilMailOntvangen) (not this.wilMailOntvangen)}}
+      />
+
+      {{#if this.wilMailOntvangen}}
+        <div>
+          <AuLabel for="voorkeurenmailadres">E-mailadres</AuLabel>
+          <AuInput
+            id="voorkeurenmailadres"
+            @width="block"
+            @value={{this.emailAddress}}
+            {{auto-focus}}
+          />
+          <AuHelpText>vb. mail@adres.com</AuHelpText>
+        </div>
+      {{/if}}
+    </form>
+  </Modal.Body>
+  <Modal.Footer>
+    <AuButtonGroup>
+      {{! TODO: Replace this with an AuButton component once we update to 3.25+: https://github.com/emberjs/ember.js/issues/18232 }}
+      <button
+        class="au-c-button au-c-button--primary"
+        form="notification-preferences-form"
+        type="submit"
+      >
+        Bewaar
+      </button>
+      <AuButton {{on "click" @close}} @skin="secondary">
+        Sluit venster en verwerp wijzigingen
+      </AuButton>
+    </AuButtonGroup>
+  </Modal.Footer>
+</AuModal>

--- a/app/components/submissions/notification-preferences.js
+++ b/app/components/submissions/notification-preferences.js
@@ -1,0 +1,23 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class NotificationPreferencesComponent extends Component {
+  @service currentSession;
+
+  @tracked wilMailOntvangen = this.currentSession.group.wilMailOntvangen;
+  @tracked emailAddress = this.currentSession.group.mailAdres;
+
+  @action
+  savePreferences(event) {
+    event.preventDefault();
+
+    let group = this.currentSession.group;
+    group.mailAdres = this.emailAddress;
+    group.wilMailOntvangen = this.wilMailOntvangen;
+    group.save();
+
+    this.args.close();
+  }
+}

--- a/app/controllers/search/submissions.js
+++ b/app/controllers/search/submissions.js
@@ -2,6 +2,7 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { typeOf } from '@ember/utils';
+import { tracked } from '@glimmer/tracking';
 
 export default class SearchSubmissionsController extends Controller {
   @service router;
@@ -9,6 +10,8 @@ export default class SearchSubmissionsController extends Controller {
 
   page = 0;
   size = 20;
+
+  @tracked preferences = false;
 
   get hasActiveChildRoute() {
     return (
@@ -30,5 +33,15 @@ export default class SearchSubmissionsController extends Controller {
   @action
   updateQueryParams() {
     this.filter.keys.forEach((key) => (key = this.filter[key]));
+  }
+
+  @action
+  showPreferences() {
+    this.preferences = true;
+  }
+
+  @action
+  hidePreferences() {
+    this.preferences = false;
   }
 }

--- a/app/models/bestuurseenheid.js
+++ b/app/models/bestuurseenheid.js
@@ -3,6 +3,8 @@ import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 export default class Bestuurseenheid extends Model {
   @attr() naam;
   @attr('string-set') alternatieveNaam;
+  @attr() mailAdres;
+  @attr() wilMailOntvangen;
 
   @belongsTo('werkingsgebied', { inverse: null }) werkingsgebied;
   @belongsTo('werkingsgebied', { inverse: null }) provincie;

--- a/app/templates/search/submissions.hbs
+++ b/app/templates/search/submissions.hbs
@@ -10,6 +10,12 @@
                   Inzendingen beschikbaar voor {{this.currentSession.groupName}}
                 </AuHeading>
               </Group>
+              <Group>
+                <button type="button" class="au-c-button au-c-button--tertiary" {{on 'click' this.showPreferences}}>
+                  <AuIcon @icon="settings" @alignment="left" />
+                  Ontvang mails bij nieuwe inzendingen
+                </button>
+              </Group>
             </AuToolbar>
             <Submissions::SearchTable
               @model={{this.model}}
@@ -25,6 +31,11 @@
         </div>
         {{outlet}}
       </div>
+        {{#if this.preferences}}
+        <Submissions::NotificationPreferences
+          @close={{this.hidePreferences}}
+        />
+        {{/if}}
     </div>
   </div>
 </div>


### PR DESCRIPTION
# Description
DL-5177

This PR is about adding the notification feature.

- Adding modal where administrative units can subscribe with their e-mail address to receive e-mail notifications when a new submission is available.
- Updating the bestuurseenheid model.


# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services (not included yet)

- worship-submissions-email-notification-service
- deliver-email-service

# How to test

1. Log as any administrative unit.
2. Click on "Ontvang mails bij nieuwe inzendingen" .
![Screenshot 2023-05-31 at 12-20-18 Erediensten Toezichtsdatabank](https://github.com/lblod/frontend-worship-decisions/assets/38471754/36033dad-9e7e-403e-bf39-d0403867f7ef)
3. A modal should popup where you can set an e-mail address.
4. Filling the address and validating should update the email value and set wilMailOntvangen  to `true` from the bestuurseenheid (administrative-unit).

# What to check

- Email and wilMailOntvangen should be updated for bestuurseenheid.
- Typo issues.

# Links to other PR's

N/A

# Notes

N/A
