### PR TITLE
Bump ember-submission-form-fields v2.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@glimmer/tracking": "^1.0.4",
     "@lblod/ember-acmidm-login": "^1.3.0",
     "@lblod/ember-mock-login": "^0.7.0",
-    "@lblod/ember-submission-form-fields": "^2.0.0",
+    "@lblod/ember-submission-form-fields": "^2.11.0",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "ember-auto-import": "^2.4.1",


### PR DESCRIPTION
# Description
DL-5180

This PR is about updating `ember-submission-form-fields` to v2.11.0 to use the new alert field in the Besluit handhaven na ontvangst schorsingsbesluit (besluit handhaven) form.

- Bumping `ember-submission-form-fields` to v2.11.0

See feature -> https://github.com/lblod/ember-submission-form-fields/commit/3ed7941cb2ac392e866de8d593d965bdedaf6210


# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

# Related module

- https://github.com/lblod/ember-submission-form-fields

# Notes

**Bump frontend**
