### PR TITLE
[ Filter-form ] Allow filtering from a specific date

### DIFF
--- a/app/routes/search/submissions.js
+++ b/app/routes/search/submissions.js
@@ -87,7 +87,7 @@ export default class SearchSubmissionsRoute extends Route {
       const formattedDate = sessionDate.toISOString().split('T')[0];
       query['filter[form-data][session-started-at-time]'] = formattedDate;
     }
-    
+
     if (params.sessionDateFrom)
       query['filter[form-data][:gte:session-started-at-time]'] =
         params.sessionDateFrom;
@@ -128,7 +128,6 @@ export default class SearchSubmissionsRoute extends Route {
       const formattedDate = sessionDate.toISOString().split('T')[0];
       query['sessionDatetime'] = formattedDate;
     }
-    
     if (params.sessionDateFrom)
       query[':gte:sessionDatetime'] = params.sessionDateFrom;
     if (params.sessionDateTo)

--- a/app/routes/search/submissions.js
+++ b/app/routes/search/submissions.js
@@ -82,6 +82,12 @@ export default class SearchSubmissionsRoute extends Route {
           params.regulationTypes;
     }
 
+    if (params.sessionDateTime) {
+      const sessionDate = new Date(params.sessionDateTime);
+      const formattedDate = sessionDate.toISOString().split('T')[0];
+      query['filter[form-data][session-started-at-time]'] = formattedDate;
+    }
+    
     if (params.sessionDateFrom)
       query['filter[form-data][:gte:session-started-at-time]'] =
         params.sessionDateFrom;
@@ -117,6 +123,12 @@ export default class SearchSubmissionsRoute extends Route {
       if (params.regulationTypes)
         query[':terms:regulationTypeURI'] = params.regulationTypes;
     }
+    if (params.sessionDateTime) {
+      const sessionDate = new Date(params.sessionDateTime);
+      const formattedDate = sessionDate.toISOString().split('T')[0];
+      query['sessionDatetime'] = formattedDate;
+    }
+    
     if (params.sessionDateFrom)
       query[':gte:sessionDatetime'] = params.sessionDateFrom;
     if (params.sessionDateTo)

--- a/app/utils/filter-form-helpers.js
+++ b/app/utils/filter-form-helpers.js
@@ -96,6 +96,7 @@ export function getQueryParams(options) {
     provinces: options,
     decisionTypes: options,
     regulationTypes: options,
+    sessionDateTime: options,
     sessionDateFrom: options,
     sessionDateTo: options,
     sentDateFrom: options,


### PR DESCRIPTION
# Description
DL-5329

This PR essentially adds a new field where the user is now allowed to perform filtering based on one date (without time).

Users (context ERE) know specific dates they want to filter for. Currently if they’re looking for documents from 01/01/2023 they have to filter 01/01/2023-02/01/2023 which gives them way more results to look at than they need, prolonging and hindering their search. Ideally they should just select 1 date in the filters instead of having to select a start- and end date.

An ideal solution would be to have a field (this has to be a new component I think) where the date range is shared with this field, like so :
Label -> Periode zitting/besluit
Buttons -> Alle meldingen - specifieke periode - specifieke datum <- This is the one we add 

This would make it less redundant than having two 'same' date fields. Right now this PR is about the quickest solution but I don't know how many changes it will take to implement the ideal solution.


# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- [search-query-management](https://github.com/lblod/toezicht-search-query-management-service)

# How to test 

1. Run on both branches from backend and frontend (They have the same name)
2. Log as any administrative units that have a lot of submission (e.g : Aalst)
3. Use the filter by typing one date.
4. It should filter by the date without the time


# Links to other PR's

- https://github.com/lblod/app-worship-decisions-database/pull/46

# Notes

drc restart search-query-management

To be merged with https://github.com/lblod/app-worship-decisions-database/pull/46
