### PR TITLE
[DL-5637] Sort submissions by sent date

### DIFF
--- a/app/controllers/search/submissions.js
+++ b/app/controllers/search/submissions.js
@@ -10,7 +10,7 @@ export default class SearchSubmissionsController extends Controller {
 
   page = 0;
   size = 20;
-  sort = 'organization.naam'; // Note : this is a temporary fix, clicking on the sorting will still make submissions disappear but now they're shown by default.
+  sort = '-sent-date';
 
   @tracked preferences = false;
 


### PR DESCRIPTION
This changes the default sorting to the sent date so the last submitted entries are displayed on top.