### PR TITLE
[DL-5661] Fix the ACM/IDM login

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -12,9 +12,11 @@ module.exports = function (defaults) {
     staticHelpers: true,
     staticModifiers: true,
     staticComponents: true,
-    staticEmberSource: true,
-    amdCompatibility: {
-      es: [['fetch', ['default', 'Headers']]], // Used by @lblod/ember-acmidm-login v1.4, we can remove this once we update to v2
-    },
+    // Disabled for now, since it causes issues for the virtual `rsvp` module.
+    // We can enable this again once we update to ember-acmidm-login v2
+    // staticEmberSource: true,
+    // amdCompatibility: {
+    //   es: [['fetch', ['default', 'Headers']]], // Used by @lblod/ember-acmidm-login v1.4, we can remove this once we update to v2
+    // },
   });
 };


### PR DESCRIPTION
`staticEmberSource` seems to remove the `rsvp` module, even though it is used by the ACM/IDM login flow. This breaks the popup that should be shown when clicking the login buttons.

We disable that flag for now, until we update to ember-acmidm-login v2.