### PR TITLE
Update to Appuniversum 3.1+

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "torii": "torii is used by ember-acmidm-login but v1.0.0-beta fixes some Ember 4 issues"
   },
   "devDependencies": {
-    "@appuniversum/ember-appuniversum": "^3.0.0",
+    "@appuniversum/ember-appuniversum": "^3.3.0",
     "@babel/eslint-parser": "^7.23.10",
     "@babel/plugin-proposal-decorators": "^7.21.0",
     "@ember/optional-features": "^2.0.0",
@@ -52,6 +52,7 @@
     "@lblod/ember-acmidm-login": "^1.3.0",
     "@lblod/ember-mock-login": "^0.10.0",
     "@lblod/ember-submission-form-fields": "^2.11.0",
+    "@zestia/ember-auto-focus": "^5.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "concurrently": "^8.0.1",
     "ember-auto-import": "^2.6.3",


### PR DESCRIPTION
Appniversum 3.1 dropped the internal usage of `@zestia/ember-auto-focus`. It seems we are using that addon here as well without depending on it explicitly, so the update to 3.1+ would break if we don't install it ourselves.