### PR TITLE
[DL-5735] Enable the 'bulk download' feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@glimmer/tracking": "^1.1.2",
         "@lblod/ember-acmidm-login": "^1.3.0",
         "@lblod/ember-mock-login": "^0.10.0",
-        "@lblod/ember-submission-form-fields": "^2.11.0",
+        "@lblod/ember-submission-form-fields": "^2.19.0",
         "@zestia/ember-auto-focus": "^5.1.0",
         "broccoli-asset-rev": "^3.0.0",
         "concurrently": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@glimmer/tracking": "^1.1.2",
     "@lblod/ember-acmidm-login": "^1.3.0",
     "@lblod/ember-mock-login": "^0.10.0",
-    "@lblod/ember-submission-form-fields": "^2.11.0",
+    "@lblod/ember-submission-form-fields": "^2.19.0",
     "@zestia/ember-auto-focus": "^5.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "concurrently": "^8.0.1",


### PR DESCRIPTION
ember-submission-form-fields v2.19 includes the bulk download feature for the files and remote-url form fields.

(Technically this change was already part of the lock file, because of the version range, but this makes it explicit).