### PR TITLE
[DL-6072] Retry accessing the original route after login

### DIFF
--- a/app/services/session.js
+++ b/app/services/session.js
@@ -38,8 +38,8 @@ export default class SessionService extends BaseSessionService {
 }
 
 // This converts a RouteInfo instance to the corresponding url by collecting all
-// the route params and query params and using the router.urlFor method
-// This is a public API reimplementation of the `transition.intent.url` property
+// the route params and query params and using the router.urlFor method.
+// This is a public API reimplementation of the `transition.intent.url` property.
 // More info: https://discord.com/channels/480462759797063690/624403666585124895/897832626616926218
 function routeInfoUrl(routeInfo, routerService) {
   let targetRoute = routeInfo.name;

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -4,6 +4,27 @@ import ENV from 'frontend-worship-decisions/config/environment';
 
 export default class SessionService extends BaseSessionService {
   @service currentSession;
+  @service router;
+
+  requireAuthentication(transition, routeOrCallback) {
+    const isAuthenticated = super.requireAuthentication(
+      transition,
+      routeOrCallback
+    );
+
+    // The user isn't authenticated. We store the url in a cookie so we can retry it after logging in.
+    if (!isAuthenticated) {
+      // By default ESA only supports retrying transitions by looking at the `attemptedTransition` property.
+      // However, this property isn't persisted, so after a page reload it is gone, which is an issue for our redirect-based ACM/IDM setup.
+      // ESA also has a cookie-based redirect setup to support FastBoot. With a little bit of code we can hook into this system
+      // so the redirect also survives a page reload.
+      const COOKIE_NAME = 'ember_simple_auth-redirectTarget'; // This is the name that ESA uses: https://github.com/mainmatter/ember-simple-auth/blob/1404c501c2ba9c8c6c071b05f38d42a057522318/packages/ember-simple-auth/src/-internals/routing.js#L37
+      const redirectUrl = routeInfoUrl(transition.to, this.router);
+      document.cookie = `${COOKIE_NAME}=${redirectUrl};path=/;samesite=strict`;
+    }
+
+    return isAuthenticated;
+  }
 
   handleAuthentication(routeAfterAuthentication) {
     super.handleAuthentication(routeAfterAuthentication);
@@ -14,4 +35,29 @@ export default class SessionService extends BaseSessionService {
     const logoutUrl = ENV.torii.providers['acmidm-oauth2'].logoutUrl;
     super.handleInvalidation(logoutUrl);
   }
+}
+
+// This converts a RouteInfo instance to the corresponding url by collecting all
+// the route params and query params and using the router.urlFor method
+// This is a public API reimplementation of the `transition.intent.url` property
+// More info: https://discord.com/channels/480462759797063690/624403666585124895/897832626616926218
+function routeInfoUrl(routeInfo, routerService) {
+  let targetRoute = routeInfo.name;
+  let allRouteParamValues = [];
+  let allRouteQueryParams = {};
+
+  routeInfo.find((routeInfo) => {
+    routeInfo.paramNames.forEach((paramName) => {
+      let paramValue = routeInfo.params[paramName];
+      allRouteParamValues.push(paramValue);
+      allRouteQueryParams = {
+        ...allRouteQueryParams,
+        ...routeInfo.queryParams,
+      };
+    });
+  });
+
+  return routerService.urlFor(targetRoute, ...allRouteParamValues, {
+    queryParams: allRouteQueryParams,
+  });
 }


### PR DESCRIPTION
When the user tries to access a route when not logged in, the transition will be stored and retried by ESA. However, this only works as long as the user doesn't reload the page. The new ACM/IDM login setup requires a redirect, which causes the transition data to be lost. To work around this we store the url of the route in a cookie, which ESA also checks after login (for FastBoot support). As a result, the transition will now be tried again, even after a page reload.

Note: This change isn't really needed for our current setup, since we still use the pop-up based login system from ember-acmidm-login v1. Once we upgrade to v2 this change would be needed for the ACM/IDM flow. For now it will at least make the mock-login flow more user friendly, since transitions will be retried again.

I've opened https://github.com/mainmatter/ember-simple-auth/issues/2808 to discuss if anything similar could be added to the addon itself, so we don't need this workaround.

**To test**

1. Log in as a mock user
2. Go to the details page of a submission
3. copy the url
4. logout
5. paste the url (you will be redirected to the login page)
6. go to the mock login route
7. login as the same user again (to ensure they have access to the submission after login)
8. verify that you are redirected to the specific details page instead of the index of the app