### PR TITLE
[DL-4983] Rename app to Databank Erediensten and adjust home page text

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Erediensten Toezichtsdatabank</title>
+    <title>Databank Erediensten</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/app/templates/error.hbs
+++ b/app/templates/error.hbs
@@ -7,7 +7,7 @@
       <p>
         Indien dit probleem zich blijft voordoen, contacteer
         <AuLinkExternal
-          href="mailto:LoketLokaalBestuur@vlaanderen.be?subject=Technisch probleem in Databank Erediensten"
+          href="mailto:LoketLokaalBestuur@vlaanderen.be?subject=Technisch probleem in {{(app-name)}}"
         >
           LoketLokaalBestuur@vlaanderen.be
         </AuLinkExternal>.

--- a/app/templates/error.hbs
+++ b/app/templates/error.hbs
@@ -7,7 +7,7 @@
       <p>
         Indien dit probleem zich blijft voordoen, contacteer
         <AuLinkExternal
-          href="mailto:LoketLokaalBestuur@vlaanderen.be?subject=Technisch probleem in Erediensten Toezichtsdatabank"
+          href="mailto:LoketLokaalBestuur@vlaanderen.be?subject=Technisch probleem in Databank Erediensten"
         >
           LoketLokaalBestuur@vlaanderen.be
         </AuLinkExternal>.

--- a/app/templates/login.hbs
+++ b/app/templates/login.hbs
@@ -14,9 +14,10 @@
 
         <LoginButton />
 
-        {{!-- TODO: Replace this for eredienst toezichtsdatabank --}}
-        <p>Dit is een publieke besluitendatabank van het Agentschap Binnenlands Bestuur. Via deze databank zijn alle meldingsplichtige besluiten terug te vinden die door de lokale besturen gemeld of ingezonden werden via het Loket voor Lokale Besturen. Meer info over dit loket vind je op volgende pagina: <AuLinkExternal href="https://lokaalbestuur.vlaanderen.be/besluitendatabank">https://lokaalbestuur.vlaanderen.be/besluitendatabank</AuLinkExternal></p>
-        <p>Lukt het aanmelden niet? Neem contact op met uw lokale beheerder. Indien er zich een probleem voordoet, contacteer <AuLinkExternal href="https://overheid.vlaanderen.be/ict/ict-diensten/gebruikersbeheer">gebruikersbeheer Vlaanderen</AuLinkExternal>.</p>
+        <p>Dit is een besluitendatabank van het Agentschap Binnenlands Bestuur. Deze databank is een verzamelplaats van inzendingen van (centrale) besturen van de eredienst, gemeenten, provincies en representatieve organen.</p>
+        <p>Dit betekent dat alle besluiten en documenten die digitaal verstuurd worden via de module Toezicht in het Loket voor Lokale Besturen daar opgeslagen worden en bekeken kunnen worden.</p>
+        <p>Meer info over deze Databank Erediensten vind je op de volgende pagina: <AuLinkExternal href="https://abb-vlaanderen.gitbook.io/handleiding-loket/erediensten/databank-erediensten">https://abb-vlaanderen.gitbook.io/handleiding-loket/erediensten/databank-erediensten</AuLinkExternal>.</p>
+        <p>Lukt het aanmelden niet? Neem contact op met uw lokale beheerder. Indien er zich een probleem voordoet, contacteer <AuLinkExternal href="https://www.vlaanderen.be/digitaal-vlaanderen/onze-oplossingen/veiligheidsbouwstenen-applicatie-en-platformdiensten/gebruikers-en-rechten-tot-je-digitale-toepassingen-beheren">gebruikersbeheer Vlaanderen</AuLinkExternal>.</p>
         <p>Het aanmelden gebeurt in een pop-up; zorg dat de instellingen van uw browser correct staan indien deze niet verschijnt.</p>
       </AuContent>
     </div>

--- a/config/environment.js
+++ b/config/environment.js
@@ -18,7 +18,7 @@ module.exports = function (environment) {
       // Here you can pass flags/options to your application instance
       // when it is created
     },
-    appName: 'Erediensten Toezichtsdatabank',
+    appName: 'Databank Erediensten',
     moment: {
       allowEmpty: true,
     },


### PR DESCRIPTION
## Ticket Number

DL-4983

## PR Description

* Renames app from `Erediensten Toezichtsdatabank` to `Databank Erediensten` to be more line with the module name from Loket.
* Adjusts home page text.