### PR TITLE
Update the admin role

### DIFF
--- a/app/services/current-session.js
+++ b/app/services/current-session.js
@@ -2,7 +2,7 @@ import Service from '@ember/service';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
-const ADMIN_ROLE = 'LoketLB-admin';
+const ADMIN_ROLE = 'LoketLB-AdminDatabankErediensten';
 
 export default class CurrentSessionService extends Service {
   @service impersonation;


### PR DESCRIPTION
We now have a dedicated admin role for the worship decisions DB, so we should use that instead of the generic admin.