### PR TITLE
fix the broken decisionTypes multiSelect

### DIFF
--- a/app/routes/search/submissions.js
+++ b/app/routes/search/submissions.js
@@ -75,7 +75,14 @@ export default class SearchSubmissionsRoute extends Route {
       query['filter[organization][provincie][:uri:]'] = params.provinces;
 
     if (params.decisionTypes) {
-      query['filter[form-data][decision-type][:uri:]'] = params.decisionTypes;
+      const decisionTypesUriList = params.decisionTypes.split(',');
+      const decisionTypesIdList = decisionTypesUriList
+        .map((p) => {
+          const parts = p.split('/');
+          return parts[parts.length - 1];
+        })
+        .join(',');
+      query['filter[form-data][decision-type][:id:]'] = decisionTypesIdList;
 
       if (params.regulationTypes)
         query['filter[form-data][regulation-type][:uri:]'] =


### PR DESCRIPTION
## ID

DL-6665

## Description

Similar to https://github.com/lblod/frontend-subsidiedatabank/pull/6 in subsidiedatabank we have a broken multi select for decisionTypes which can be resolved by filtering on id instead of uri's.

The regexing is a bit cumbersome, but the alternative would be to do a store request to get the data model and get the id from there, which would require adding a decisionType model file first as well.