### PR TITLE
DL-7139: extract correct decision type to prevent loop

### DIFF
--- a/app/components/submissions/fields/decision-documents-field.gjs
+++ b/app/components/submissions/fields/decision-documents-field.gjs
@@ -20,6 +20,9 @@ import { formatDate } from 'frontend-worship-decisions/utils/date';
 import { isRequiredField } from 'frontend-worship-decisions/utils/semantic-forms';
 import { AddDocumentsModal } from './-shared/add-documents-modal';
 import { extractDocumentsFromTtl } from './-shared/utils';
+import { NamedNode } from 'rdflib';
+import { SKOS } from '../../../rdf/namespaces';
+import { DECISION_TYPE } from '../../../models/concept-scheme';
 
 export function registerFormField() {
   registerFormFields([
@@ -61,12 +64,23 @@ class DecisionDocumentsField extends Component {
   }
 
   get decisionType() {
-    return this.args.formStore.any(
+    const rdfTypes = this.args.formStore.match(
       this.args.sourceNode,
       RDF('type'),
       undefined,
       this.args.graphs.sourceGraph,
+    ).map((quad) => quad.object);
+    const toezichtDossierTypeConceptScheme = new NamedNode(
+      DECISION_TYPE,
     );
+    return rdfTypes.find((rdfType) => {
+      return this.args.formStore.any(
+        rdfType,
+        SKOS('inScheme'),
+        toezichtDossierTypeConceptScheme,
+        undefined,
+      );
+    });
   }
 
   get path() {


### PR DESCRIPTION
### Overview
This PR fixes a bug in the logic of the `decisionType` getter to ensure that the extracted type is a decision type.
This fix also solves the issue where municipalities got shown a 'related document' link pointing to itself.


##### connected issues and PRs:
[DL-7139](https://binnenland.atlassian.net/browse/DL-7139?atlOrigin=eyJpIjoiMTFlMzdiZThmOGY2NGM1MDg0NzExNDhkMTA1ZTk2OWQiLCJwIjoiaiJ9)

### How to test/reproduce
- Connect the frontend to a database of choice
- Log in as a municipality
- Search for a bundled submission made by a CKB
- Ensure that you can now see the original decision submission in the 'related documents' section
- Do not that the link listed will not resolve as the municipality does not have access to the original decisions (determined by the business rules)

