### PR TITLE
DL-7170: filter out empty responses from cross reference service

### DIFF
--- a/app/components/submissions/fields/decision-articles-field.gjs
+++ b/app/components/submissions/fields/decision-articles-field.gjs
@@ -34,6 +34,7 @@ import { v4 as uuid } from 'uuid';
 import { ConceptSchemeSelect } from './-shared/concept-scheme-select';
 import { AddDocumentsModal } from './-shared/add-documents-modal';
 import { extractDocumentsFromTtl } from './-shared/utils';
+import { isSome } from '../../../utils/option';
 
 const hasPart = ELI('has_part');
 const documentType = ELI('type_document');
@@ -348,7 +349,7 @@ class ArticleDetails extends Component {
         }
       });
 
-    const decisions = await Promise.all(decisionsPromises);
+    const decisions = (await Promise.all(decisionsPromises)).filter(isSome);
 
     this.decisions = decisions;
   });

--- a/app/components/submissions/fields/decision-documents-field.gjs
+++ b/app/components/submissions/fields/decision-documents-field.gjs
@@ -23,6 +23,7 @@ import { extractDocumentsFromTtl } from './-shared/utils';
 import { NamedNode } from 'rdflib';
 import { SKOS } from '../../../rdf/namespaces';
 import { DECISION_TYPE } from '../../../models/concept-scheme';
+import { isSome } from '../../../utils/option';
 
 export function registerFormField() {
   registerFormFields([
@@ -119,7 +120,6 @@ class DecisionDocumentsField extends Component {
 
       if (response.ok) {
         const ttlData = await response.text();
-
         if (ttlData.length > 0) {
           let data = extractDocumentsFromTtl(ttlData);
 
@@ -132,7 +132,7 @@ class DecisionDocumentsField extends Component {
       }
     });
 
-    this.documents = await Promise.all(documentPromises);
+    this.documents = (await Promise.all(documentPromises)).filter(isSome);
   });
 
   addDocuments = (documentsToAdd) => {

--- a/app/utils/option.js
+++ b/app/utils/option.js
@@ -1,0 +1,3 @@
+export function isSome(value) {
+  return value !== null && value !== undefined;
+}


### PR DESCRIPTION
### Overview
Both the `decision-documents-field` and `decision-articles-field` components don't fully take empty responses from the `cross-reference-service` into account.
If the the `cross-reference-service` doesn't return any document information, empty rows would show up in the tables of the components.

This PR ensures that empty/undefined entries of the `documents`/`decisions` array are being filtered out.

##### connected issues and PRs:
DL-7170


### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] npm lint
- [ ] no new deprecations
