### PR TITLE
DL-7337: fix the "download all as zip" feature

### DIFF
--- a/app/components/submissions/fields/decision-remote-documents.gjs
+++ b/app/components/submissions/fields/decision-remote-documents.gjs
@@ -496,10 +496,10 @@ export default class DecisionRemoteDocumentsShowComponent extends Component {
 
   downloadAsZip = task(async () => {
     const promises = this.downloadableRemoteUrls.map((rdo) => {
-      return fetch(rdo.downloadLink).then((response) => {
+      return fetch(downloadLink(rdo)).then((response) => {
         if (!response.ok) {
           throw new Error(
-            `Something went wrong while trying to download '${rdo.downloadLink}': ${response.status} ${response.statusText}`,
+            `Something went wrong while trying to download '${downloadLink(rdo)}': ${response.status} ${response.statusText}`,
           );
         }
         return response;


### PR DESCRIPTION
- switched rdo.downloadLink with downloadLink(rdo) because it leads to undefined calls when downloading the zip.

TO TEST:
- rsync prod db
- rsync specific files from PRD for the submission shown in the jira ticket (Probably there is a better way to handle this)
- check that you can download the zip